### PR TITLE
Model based Proposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+*v1.1.0*
+_Feat: Add support for State based propositions_
+> Basically this injects the current model representation when the
+passed proposition is a Function.
+
 *v1.0.2*
 _Fix: Drop JSX syntax in favor of vanilla JS_
 > This settle the building errors without the need of building the library.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "description": "Invisible's Frontend Stack using Mobx, React and SAM Pattern",
   "name": "@invisible/samx",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "src/index.js",
   "repository": "git@github.com:invisible-tech/samx.git",
   "author": "Invisible Technologies Inc. <engineering@invisible.email>",

--- a/src/model.js
+++ b/src/model.js
@@ -32,13 +32,16 @@ export const Model = (name , { schema, acceptor }) => {
     runInAction(name, () => { set(model, value) })
   }
 
-  model.propose = isUndefined(acceptor)
-    ? modelSetter
-    : proposition => {
-      d(`Calling acceptor for ${name}`)
-      const currentModel = modelGetter(model)
-      acceptor(modelSetter, proposition, currentModel)
-    }
+  model.propose = proposition => {
+    const currentModel = modelGetter(model)
+    if (proposition instanceof Function) proposition = proposition(currentModel)
+
+    if (isUndefined(acceptor)) return modelSetter(proposition)
+    else return proposition => {
+        d(`Calling acceptor for ${name}`)
+        acceptor(modelSetter, proposition, currentModel)
+      }
+  }
 
   registerModel(name, model)
 }


### PR DESCRIPTION
My solution for having smarter proposers that can leverage current model state when evaluating a new proposal.
This will result in smarter proposers and dummier actions, which I think it's OK since Actions could hold API calls and other async behaviours and the proposer just a pure function that ties together third-party data and the current model state.